### PR TITLE
fix: Make it work correctly in visual mode

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -113,6 +113,8 @@ end
 function M:entry(args)
   local default_fmt = args[1]
 
+  ya.manager_emit("escape", { visual = true })
+
   -- Get the files that need to be compressed and infer a default archive name
   local paths, default_name = get_compression_target()
 


### PR DESCRIPTION
Make it work correctly in visual mode.

before(doesn't work in visual mode)
It selects only `README.md`
Commit hash: d13f7c08


https://github.com/user-attachments/assets/33eb05c0-6a97-49e2-80cd-afe0c5081f24



atfer(work correctly in visual mode)
Commit has: 53517325


https://github.com/user-attachments/assets/ff524766-4b21-403d-b40c-9b7c4e186713


using yazi hash: 6086134

The reason I used an older version is that the latest one could not be built.
```
yazi --debug

Yazi
    Version: 0.3.3 (6086134 2024-11-11)
    Debug  : false
    OS     : linux-x86_64 (unix)

Ya
    Version: 0.3.3 (7c445ce 2024-09-04)

Emulator
    Emulator.via_env: ("xterm-256color", "WezTerm")
    Emulator.via_csi: Ok(WezTerm)
    Emulator.detect : WezTerm

Adapter
    Adapter.matches: Iip

Desktop
    XDG_SESSION_TYPE           : Some("wayland")
    WAYLAND_DISPLAY            : Some("wayland-0")
    DISPLAY                    : Some(":1")
    SWAYSOCK                   : None
    HYPRLAND_INSTANCE_SIGNATURE: None
    WAYFIRE_SOCKET             : None

SSH
    shared.in_ssh_connection: false

WSL
    WSL: false

Variables
    SHELL              : Some("/usr/bin/bash")
    EDITOR             : Some("vim")
    VISUAL             : None
    YAZI_FILE_ONE      : None
    YAZI_CONFIG_HOME   : None

Text Opener
    default     : Some(Opener { run: "${EDITOR:-vi} \"$@\"", block: true, orphan: false, desc: "$EDITOR", for_: None, spread: true })
    block-create: Some(Opener { run: "${EDITOR:-vi} \"$@\"", block: true, orphan: false, desc: "$EDITOR", for_: None, spread: true })
    block-rename: Some(Opener { run: "${EDITOR:-vi} \"$@\"", block: true, orphan: false, desc: "$EDITOR", for_: None, spread: true })

Multiplexers
    TMUX               : false
    tmux version       : No such file or directory (os error 2)
    tmux build flags   : enable-sixel=Unknown
    ZELLIJ_SESSION_NAME: None
    Zellij version     : No such file or directory (os error 2)

Dependencies
    file             : 5.44
    ueberzugpp       : No such file or directory (os error 2)
    ffmpegthumbnailer: No such file or directory (os error 2)
    magick           : No such file or directory (os error 2)
    fzf              : 0.54.1
    fd               : No such file or directory (os error 2)
    rg               : 13.0.0
    chafa            : 1.12.4
    zoxide           : 0.9.6
    7z               : 16.02
    7zz              : No such file or directory (os error 2)
    jq               : 1.6


--------------------------------------------------
When reporting a bug, please also upload the `yazi.log` log file - only upload the most recent content by time.
You can find it in the "/home/user/.local/state/yazi" directory.


```