### PR TITLE
docs: fix plugin args example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For compession, add this to your `keymap.toml`:
 ```toml
 [[manager.prepend_keymap]]
 on = ["C"]
-run = "plugin ouch --args=zip"
+run = "plugin ouch zip"
 desc = "Compress with ouch"
 ```
 


### PR DESCRIPTION
From the [docs](https://yazi-rs.github.io/docs/plugins/overview#functional-plugin):

> For example, `plugin test -- foo --bar --baz=qux` will run the `test` plugin with the arguments `foo --bar --baz=qux` in an async context.
> 
> To access the arguments in the plugin, use `job.args`:
> 
> ```lua
> -- ~/.config/yazi/plugins/test.yazi/main.lua
> return {
> 	entry = function(self, job)
> 		ya.dbg(job.args[1])  -- "foo"
> 		ya.dbg(job.args.bar) -- true
> 		ya.dbg(job.args.baz) -- "qux"
> 	end,
> }
> ```

Possibly fixes https://github.com/ndtoan96/ouch.yazi/issues/18