### PR TITLE
error mime type for ".tar.xz"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ prepend_previewers = [
 	{ mime = "application/x-bzip2",         run = "ouch" },
 	{ mime = "application/x-7z-compressed", run = "ouch" },
 	{ mime = "application/x-rar",           run = "ouch" },
-	{ mime = "application/x-xz",            run = "ouch" },
+	{ mime = "application/xz",              run = "ouch" },
 ]
 ```
 


### PR DESCRIPTION
![图片](https://github.com/user-attachments/assets/1fcca467-aa44-44f6-b347-b67e84c17a9c)

For reasons unknown to me, the MIME type of `.tar.xz` in Yazi is `application/xz` instead of `application/x-xz`.