### PR TITLE
Fix Windows opener command so `%*` expands correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To decompress with `ouch`, configure the opener in `yazi.toml`.
 ```toml
 [opener]
 extract = [
-	{ run = 'ouch d -y "%*"', desc = "Extract here with ouch", for = "windows" },
+	{ run = 'ouch d -y %*', desc = "Extract here with ouch", for = "windows" },
 	{ run = 'ouch d -y "$@"', desc = "Extract here with ouch", for = "unix" },
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ prepend_previewers = [
 	{ mime = "application/x-bzip2",         run = "ouch" },
 	{ mime = "application/x-7z-compressed", run = "ouch" },
 	{ mime = "application/x-rar",           run = "ouch" },
-        { mime = "application/x-xz",            run = "ouch" },
+	{ mime = "application/x-xz",            run = "ouch" },
 	{ mime = "application/xz",              run = "ouch" },
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you want to change the icon or the style of text, you can modify the `peek` f
 For compession, add this to your `keymap.toml`:
 
 ```toml
-[[manager.prepend_keymap]]
+[[mgr.prepend_keymap]]
 on = ["C"]
 run = "plugin ouch"
 desc = "Compress with ouch"


### PR DESCRIPTION
On Windows the `%*` placeholder must remain unquoted for yazi to substitute the selected files. Wrapping it in `"%*"` prevented expansion and passed the literal `%*` to the shell.

Tested on Windows PowerShell and Command Prompt.

\+ other minor improvements in README.md