### PR TITLE
Fix the misuse of `x-` and `vnd.` prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For archive preview, add this to your `yazi.toml`:
 
 ```toml
 [[plugin.prepend_previewers]]
-mime = "application/{zip,tar,bzip2,7z*,rar,xz,zstd,java-archive}"
+mime = "application/{*zip,tar,bzip2,7z*,rar,xz,zstd,java-archive}"
 run  = "ouch"
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,7 @@ For archive preview, add this to your `yazi.toml`:
 [plugin]
 prepend_previewers = [
 	# Archive previewer
-	{ mime = "application/*zip",            run = "ouch" },
-	{ mime = "application/tar",           run = "ouch" },
-	{ mime = "application/bzip2",         run = "ouch" },
-	{ mime = "application/7z-compressed", run = "ouch" },
-	{ mime = "application/rar",           run = "ouch" },
-	{ mime = "application/xz",              run = "ouch" },
-	{ mime = "application/zstd",            run = "ouch" },
-	{ mime = "application/java-archive",    run = "ouch" },
+	{ mime = "application/{zip,tar,bzip2,7z*,rar,xz,zstd,java-archive}", run = "ouch" },
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,14 +39,11 @@ For archive preview, add this to your `yazi.toml`:
 prepend_previewers = [
 	# Archive previewer
 	{ mime = "application/*zip",            run = "ouch" },
-	{ mime = "application/x-tar",           run = "ouch" },
-	{ mime = "application/x-bzip2",         run = "ouch" },
-	{ mime = "application/x-7z-compressed", run = "ouch" },
-	{ mime = "application/x-rar",           run = "ouch" },
-	{ mime = "application/vnd.rar",         run = "ouch" },
-	{ mime = "application/x-xz",            run = "ouch" },
+	{ mime = "application/tar",           run = "ouch" },
+	{ mime = "application/bzip2",         run = "ouch" },
+	{ mime = "application/7z-compressed", run = "ouch" },
+	{ mime = "application/rar",           run = "ouch" },
 	{ mime = "application/xz",              run = "ouch" },
-	{ mime = "application/x-zstd",          run = "ouch" },
 	{ mime = "application/zstd",            run = "ouch" },
 	{ mime = "application/java-archive",    run = "ouch" },
 ]

--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@ Make sure you have [ouch](https://github.com/ouch-org/ouch) installed and in you
 For archive preview, add this to your `yazi.toml`:
 
 ```toml
-[plugin]
-prepend_previewers = [
-	# Archive previewer
-	{ mime = "application/{zip,tar,bzip2,7z*,rar,xz,zstd,java-archive}", run = "ouch" },
-]
+[[plugin.prepend_previewers]]
+mime = "application/{zip,tar,bzip2,7z*,rar,xz,zstd,java-archive}"
+run  = "ouch"
 ```
 
 Now go to an archive on Yazi, you should see the archive's content in the preview pane. You can use `J` and `K` to roll up and down the preview.


### PR DESCRIPTION
- https://github.com/ndtoan96/ouch.yazi/commit/bf79f6fc15967f335191a3bc11a009df64980ab4 fixes the misuse of `x-` and `vnd.` prefixes - they have been removed since Yazi v0.4 in:
  - https://github.com/sxyazi/yazi/pull/1927
  - https://github.com/sxyazi/yazi/pull/1995

- https://github.com/ndtoan96/ouch.yazi/commit/4abecb0601e916e285aac6e8dbc01b7fd358e5d7 merges multiple rules into one for better simplicity

- https://github.com/ndtoan96/ouch.yazi/commit/f772b550df603d9a72d54618186ae74c3bb6c2b3 avoids inline tables so that it won't rewrite the `prepend_previewers` table that the user may already have

Thank you for this amazing plugin!