### PR TITLE
fix: remove deprecated position property

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -170,7 +170,6 @@ function M:entry(job)
   local output_name, name_event = ya.input({
     title = "Create archive:",
     value = default_name .. "." .. default_fmt,
-    position = { "top-center", y = 3, w = 40 },
     pos = { "top-center", y = 3, w = 40 },
   })
   if name_event ~= 1 then
@@ -181,7 +180,6 @@ function M:entry(job)
   if file_exists(output_name) then
     local confirm, confirm_event = ya.input({
       title = "Overwrite " .. output_name .. "? (y/N)",
-      position = { "top-center", y = 3, w = 40 },
       pos = { "top-center", y = 3, w = 40 },
     })
     if not (confirm_event == 1 and confirm:lower() == "y") then


### PR DESCRIPTION
## Summary
- Remove deprecated `position` property from `ya.input()` calls
- Keep only `pos` property for yazi 25.x compatibility

See https://github.com/sxyazi/yazi/pull/2921 for details.

## Test plan
- [x] Tested compression with yazi 25.x on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)